### PR TITLE
fix: normalise <br /> to <br> to match CKEditor storage format

### DIFF
--- a/src/sanitize.js
+++ b/src/sanitize.js
@@ -37,7 +37,7 @@ function sanitize(text) {
 
   const preCleaned = stripMsOfficeArtifacts(text);
 
-  return sanitizeHtml(preCleaned, {
+  const result = sanitizeHtml(preCleaned, {
     allowedTags: ['h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'blockquote', 'p', 'a', 'ul', 'ol', 'li',
       'b', 'i', 'strong', 'em', 'strike', 'br', 'table', 'thead', 'caption', 'tbody', 'tfoot',
       'tr', 'th', 'td', 'iframe', 'img', 'button'],
@@ -56,6 +56,12 @@ function sanitize(text) {
       div: 'p',
     },
   });
+
+  // sanitize-html outputs void elements as XHTML self-closing (<br />, <img ... />).
+  // CKEditor normalises these to HTML5 form (<br>, <img ...>) on every render.
+  // Without this fix the stored value and the sanitized value would differ on
+  // every page load, causing an infinite dirty-form / re-save loop.
+  return result.replace(/<(br|img)([^>]*?)\s*\/>/gi, '<$1$2>');
 }
 
 module.exports = { sanitize, stripMsOfficeArtifacts };

--- a/test/sanitize.test.js
+++ b/test/sanitize.test.js
@@ -54,6 +54,20 @@ test('keeps allowed inline tags (b, i, strong, em, a)', () => {
   assert.ok(/<a href="https:\/\/example\.com" title="t" target="_blank" rel="noopener">link<\/a>/.test(out));
 });
 
+test('<br /> is normalised to <br> to match CKEditor output (prevents infinite dirty loop)', () => {
+  assert.strictEqual(sanitize('<p>line1<br>line2</p>'), '<p>line1<br>line2</p>');
+  assert.strictEqual(sanitize('<p>line1<br />line2</p>'), '<p>line1<br>line2</p>');
+  assert.strictEqual(sanitize('<p>line1<BR/>line2</p>'), '<p>line1<br>line2</p>');
+});
+
+test('real-world: br normalisation is idempotent with CKEditor round-trip', () => {
+  // Simulate: plugin sanitizes → CKEditor stores <br> → plugin sanitizes again
+  const afterPlugin = sanitize('<p>A<br>B</p>');      // CKEditor input
+  const afterCKEditor = afterPlugin;                   // CKEditor keeps <br> unchanged
+  const afterPlugin2 = sanitize(afterCKEditor);
+  assert.strictEqual(afterPlugin, afterPlugin2, 'must be stable across CKEditor round-trips');
+});
+
 test('converts <div> to <p>', () => {
   assert.strictEqual(sanitize('<div>x</div>'), '<p>x</p>');
 });


### PR DESCRIPTION
sanitize-html emits XHTML self-closing void tags (<br />, <img ... />). CKEditor normalises them to HTML5 form (<br>, <img ...>) on every render and save. This caused a permanent mismatch: on every page load the stored value differed from the sanitized value, so the plugin marked the form dirty, requiring another save — endlessly.

Fix: post-process sanitize-html output with a regex that strips the self-closing slash from void tags, matching CKEditor exactly.

Added two test cases covering the br normalisation and idempotency across a CKEditor round-trip.