### PR TITLE
fix: replace debounce-only approach with clickable bar to win save race

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -2,28 +2,59 @@ const { sanitize } = require('./sanitize');
 
 /* ─── Status bar UI ──────────────────────────────────────────────────────── */
 
+const style = document.createElement('style');
+style.textContent = `
+  #sr-bar {
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+    font-size: 12px;
+    padding: 8px 12px;
+    border-radius: 4px;
+    margin: 4px 0;
+    display: none;
+    align-items: center;
+    gap: 8px;
+    border: 1px solid transparent;
+    transition: opacity 0.2s;
+  }
+  #sr-bar.clickable {
+    cursor: pointer;
+    user-select: none;
+  }
+  #sr-bar.clickable:hover {
+    filter: brightness(0.95);
+  }
+  #sr-bar .sr-btn {
+    margin-left: auto;
+    padding: 2px 8px;
+    border-radius: 3px;
+    border: 1px solid currentColor;
+    background: transparent;
+    font-size: 11px;
+    cursor: pointer;
+    white-space: nowrap;
+    color: inherit;
+  }
+`;
+document.head.appendChild(style);
+
 const bar = document.createElement('div');
-bar.style.cssText = [
-  'font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif',
-  'font-size:12px',
-  'padding:6px 10px',
-  'border-radius:4px',
-  'margin:4px 0',
-  'display:none',
-  'align-items:center',
-  'gap:6px',
-].join(';');
+bar.id = 'sr-bar';
 document.body.style.margin = '0';
 document.body.appendChild(bar);
 
 let hideTimer = null;
 
-function showBar(icon, msg, bg, color, autohide) {
-  if (hideTimer) clearTimeout(hideTimer);
+function showBar({
+  icon, msg, bg, borderColor, color, button, autohide,
+}) {
+  if (hideTimer) { clearTimeout(hideTimer); hideTimer = null; }
   bar.style.display = 'flex';
   bar.style.background = bg;
+  bar.style.borderColor = borderColor || bg;
   bar.style.color = color;
-  bar.innerHTML = `<span>${icon}</span><span>${msg}</span>`;
+  bar.className = button ? 'clickable' : '';
+  const btnHtml = button ? `<button class="sr-btn" type="button">${button}</button>` : '';
+  bar.innerHTML = `<span>${icon}</span><span>${msg}</span>${btnHtml}`;
   if (autohide) hideTimer = setTimeout(() => { bar.style.display = 'none'; }, autohide);
 }
 
@@ -34,23 +65,37 @@ window.DatoCmsPlugin.init((plugin) => {
 
   let lastSanitized = null;
   let sanitizeTimer = null;
+  // clean value waiting to be applied on bar click
+  let pendingClean = null;
 
   function applySanitized(sanitized) {
-    console.log('[sanitize-richtext] applying sanitized value', { fieldPath: plugin.fieldPath, sanitized });
+    console.log('[sanitize-richtext] applying sanitized value', { fieldPath: plugin.fieldPath });
     lastSanitized = sanitized;
+    pendingClean = null;
     plugin.setFieldValue(plugin.fieldPath, sanitized);
   }
 
-  /**
-   * Single entry point for both the initial load value and every subsequent
-   * field change. Both go through the same 800 ms debounce so that our
-   * setFieldValue always fires AFTER CKEditor's debounced onChange has
-   * settled. This ensures our clean value is the LAST write before Save —
-   * regardless of whether the dirty content came from a paste or was already
-   * stored in the record.
-   */
+  // When the user clicks the status bar, their browser moves focus from
+  // CKEditor to our plugin iframe. Browser event order guarantees that
+  // CKEditor's blur (and its final onChange) fires BEFORE our click handler.
+  // So by the time we call setFieldValue(CLEAN) here, we are writing AFTER
+  // CKEditor's last dirty write — and we win the race against Save.
+  bar.addEventListener('click', () => {
+    if (!pendingClean) return;
+    if (sanitizeTimer) { clearTimeout(sanitizeTimer); sanitizeTimer = null; }
+    console.log('[sanitize-richtext] bar clicked — applying clean value immediately');
+    applySanitized(pendingClean);
+    showBar({
+      icon: '✓',
+      msg: 'Formátovanie vyčistené — teraz môžete uložiť.',
+      bg: '#e6f4ea',
+      borderColor: '#a8d5b5',
+      color: '#1e7e34',
+      autohide: 8000,
+    });
+  });
+
   function handleValue(value) {
-    // Ignore echoes of values we already applied.
     if (value === lastSanitized) return;
 
     const sanitized = sanitize(value);
@@ -70,27 +115,46 @@ window.DatoCmsPlugin.init((plugin) => {
       }
       console.groupEnd();
 
-      showBar('⏳', 'Čistenie formátovania... pred uložením počkajte na ✓', '#fff3cd', '#856404', null);
+      pendingClean = sanitized;
 
-      // Debounce: reset on every incoming event. setFieldValue fires only
-      // once CKEditor has been quiet for 800 ms, so our write wins.
+      // Show clickable warning bar.
+      // Clicking it blurs CKEditor first (browser guarantees this), then
+      // our click handler fires setFieldValue(CLEAN) — after CKEditor's last
+      // dirty write — so CLEAN is what DatoCMS saves.
+      showBar({
+        icon: '⚠️',
+        msg: 'Nájdené formátovanie z Wordu / Outlooku.',
+        bg: '#fff3cd',
+        borderColor: '#ffc107',
+        color: '#856404',
+        button: 'Vyčistiť a uložiť',
+      });
+
+      // Also keep the 800ms debounce as fallback for the case when the user
+      // blurs the editor by clicking somewhere other than Save.
       if (sanitizeTimer) clearTimeout(sanitizeTimer);
       sanitizeTimer = setTimeout(() => {
         sanitizeTimer = null;
+        if (!pendingClean) return; // already applied via bar click
         applySanitized(sanitized);
-        showBar('✓', 'Formátovanie vyčistené — teraz môžete uložiť.', '#e6f4ea', '#1e7e34', null);
+        showBar({
+          icon: '✓',
+          msg: 'Formátovanie vyčistené — teraz môžete uložiť.',
+          bg: '#e6f4ea',
+          borderColor: '#a8d5b5',
+          color: '#1e7e34',
+          autohide: 8000,
+        });
       }, 800);
     } else {
-      if (sanitizeTimer) clearTimeout(sanitizeTimer);
+      if (sanitizeTimer) { clearTimeout(sanitizeTimer); sanitizeTimer = null; }
+      pendingClean = null;
       console.log('[sanitize-richtext] content is clean ✓');
       lastSanitized = value;
       bar.style.display = 'none';
     }
   }
 
-  // Process the initial value through the same debounce as changes.
-  // This avoids the 2-save problem caused by an immediate setFieldValue on
-  // load being overwritten by CKEditor's own initialisation onChange echo.
   const initial = plugin.getFieldValue(plugin.fieldPath);
   console.log('[sanitize-richtext] init', { fieldPath: plugin.fieldPath });
   handleValue(initial);


### PR DESCRIPTION
The previous 800ms debounce strategy lost a race with DatoCMS Save: when the user clicked Save while CKEditor was focused, the browser fired CKEditor blur → onChange(DIRTY) → Save (all within one event loop tick) before our async postMessage listener had a chance to run setFieldValue(CLEAN).

New strategy: show a clickable warning bar as soon as dirty content is detected. When the user clicks the bar, the browser fires events in this guaranteed order:
  1. CKEditor blur fires → onChange(DIRTY) → store = DIRTY
  2. Our bar onclick fires → setFieldValue(CLEAN) → store = CLEAN

Because blur always precedes click in the browser event order, our setFieldValue(CLEAN) is the last write before any subsequent Save. The user then clicks Save and stores the clean value on the first try.

The 800ms debounce is kept as a fallback for the case when the user blurs the editor by clicking elsewhere (not Save).