### PR TITLE
fix: add #root div to HTML template + extensive diagnostic logging

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>DatoCMS Plugin</title>
+  </head>
+  <body style="margin:0;padding:0;">
+    <div id="root"></div>
+  </body>
+</html>

--- a/src/index.js
+++ b/src/index.js
@@ -34,34 +34,55 @@ function StatusBar({ theme, icon, msg }) {
 /* ─── Field addon React component ────────────────────────────────────────── */
 
 function SanitizeAddon({ ctx }) {
-  const [status, setStatus] = useState(null); // null | 'sanitizing' | 'done'
+  const [status, setStatus] = useState(null);
   const lastCleanRef = useRef(null);
-  // keep a stable ref to ctx so async callbacks always see the latest version
   const ctxRef = useRef(ctx);
   ctxRef.current = ctx;
 
   const fieldValue = ctx.formValues[ctx.fieldPath];
 
+  console.log('[sanitize-richtext] SanitizeAddon render', {
+    fieldPath: ctx.fieldPath,
+    valueLength: typeof fieldValue === 'string' ? fieldValue.length : typeof fieldValue,
+    lastClean: lastCleanRef.current ? `${lastCleanRef.current.substring(0, 60)}…` : null,
+    status,
+  });
+
   useEffect(() => {
-    if (typeof fieldValue !== 'string') return;
-    if (fieldValue === lastCleanRef.current) return;
+    if (typeof fieldValue !== 'string') {
+      console.log('[sanitize-richtext] fieldValue is not a string, skipping', typeof fieldValue);
+      return;
+    }
+    if (fieldValue === lastCleanRef.current) {
+      console.log('[sanitize-richtext] value unchanged since last clean, skipping');
+      return;
+    }
 
     const clean = sanitize(fieldValue);
+    console.log('[sanitize-richtext] sanitize result', {
+      inputLength: fieldValue.length,
+      outputLength: clean.length,
+      changed: clean !== fieldValue,
+    });
 
     if (clean !== fieldValue) {
+      console.warn('[sanitize-richtext] DIRTY — calling setFieldValue');
       setStatus('sanitizing');
       lastCleanRef.current = clean;
       ctxRef.current.setFieldValue(ctxRef.current.fieldPath, clean)
         .then(() => {
+          console.log('[sanitize-richtext] setFieldValue resolved ✓');
           setStatus('done');
           setTimeout(() => setStatus(null), 8000);
         })
-        .catch(() => setStatus(null));
+        .catch((err) => {
+          console.error('[sanitize-richtext] setFieldValue error', err);
+          setStatus(null);
+        });
     } else {
       lastCleanRef.current = fieldValue;
       setStatus(null);
     }
-  // fieldValue is the only reactive dep — ctx is accessed via the stable ref
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [fieldValue]);
 
@@ -75,28 +96,56 @@ function SanitizeAddon({ ctx }) {
 }
 
 /* ─── Root management ────────────────────────────────────────────────────── */
-// The SDK calls renderFieldExtension again on every ctx change.
-// We create the React root once and re-render into it on each call.
+
 let reactRoot = null;
 
 function renderExtension(id, ctx) {
+  console.log('[sanitize-richtext] renderFieldExtension called', {
+    id,
+    fieldPath: ctx.fieldPath,
+    fieldType: ctx.field && ctx.field.attributes && ctx.field.attributes.field_type,
+    formValueKeys: Object.keys(ctx.formValues || {}),
+    mode: ctx.mode,
+  });
+
   ctx.startAutoResizer();
+
   if (!reactRoot) {
-    reactRoot = createRoot(document.getElementById('root'));
+    let container = document.getElementById('root');
+    if (!container) {
+      console.warn('[sanitize-richtext] #root not found in DOM, creating dynamically');
+      container = document.createElement('div');
+      container.id = 'root';
+      document.body.style.margin = '0';
+      document.body.appendChild(container);
+    }
+    reactRoot = createRoot(container);
+    console.log('[sanitize-richtext] React root created');
   }
+
   reactRoot.render(<SanitizeAddon ctx={ctx} />);
 }
 
 /* ─── Before-save sanitization ───────────────────────────────────────────── */
-// Safety net: if dirty content slips through to Save (e.g. user clicks Save
-// faster than the render addon can react), onBeforeItemUpsert intercepts it,
-// sanitizes all text fields, re-saves with clean content, and blocks the
-// original dirty save.
 
-let savingClean = false; // guard against recursive onBeforeItemUpsert calls
+let savingClean = false;
 
 async function beforeSave(payload, ctx) {
-  if (savingClean) return true;
+  console.log('[sanitize-richtext] onBeforeItemUpsert fired', {
+    savingClean,
+    payloadDataType: payload && payload.data && payload.data.type,
+    attributeKeys: payload && payload.data && payload.data.attributes
+      ? Object.keys(payload.data.attributes)
+      : [],
+    hasSetFieldValue: typeof ctx.setFieldValue === 'function',
+    hasSaveCurrentItem: typeof ctx.saveCurrentItem === 'function',
+    hasFormValues: !!ctx.formValues,
+  });
+
+  if (savingClean) {
+    console.log('[sanitize-richtext] savingClean=true, allowing save through');
+    return true;
+  }
 
   const attrs = (payload.data && payload.data.attributes) ? payload.data.attributes : {};
   const dirty = [];
@@ -104,47 +153,69 @@ async function beforeSave(payload, ctx) {
   for (const [key, value] of Object.entries(attrs)) {
     if (typeof value === 'string') {
       const clean = sanitize(value);
-      if (clean !== value) dirty.push({ key, clean });
+      if (clean !== value) {
+        dirty.push({ key, clean });
+        console.warn('[sanitize-richtext] dirty field (string):', key, {
+          inputLength: value.length,
+          outputLength: clean.length,
+        });
+      }
     } else if (value && typeof value === 'object') {
-      // localized field: { en: '...', cs: '...' }
       for (const [locale, localeValue] of Object.entries(value)) {
         if (typeof localeValue === 'string') {
           const clean = sanitize(localeValue);
-          if (clean !== localeValue) dirty.push({ key: `${key}.${locale}`, clean });
+          if (clean !== localeValue) {
+            dirty.push({ key: `${key}.${locale}`, clean });
+            console.warn('[sanitize-richtext] dirty field (localized):', `${key}.${locale}`);
+          }
         }
       }
     }
   }
 
-  if (dirty.length === 0) return true;
+  if (dirty.length === 0) {
+    console.log('[sanitize-richtext] all fields clean, allowing save');
+    return true;
+  }
 
-  console.warn('[sanitize-richtext] onBeforeItemUpsert: dirty fields detected', dirty.map((d) => d.key));
+  console.warn('[sanitize-richtext] blocking save to apply sanitization on:', dirty.map((d) => d.key));
 
   if (typeof ctx.setFieldValue !== 'function' || typeof ctx.saveCurrentItem !== 'function') {
-    // Fallback: alert user and block this save — render addon will clean it
+    console.warn('[sanitize-richtext] setFieldValue/saveCurrentItem not available on ctx, using alert fallback');
     await ctx.alert('Obsah obsahuje formátovanie z Wordu / Outlooku, ktoré sa práve automaticky vyčistilo. Uložte znova.');
     return false;
   }
 
   for (const { key, clean } of dirty) {
+    console.log('[sanitize-richtext] setFieldValue', key);
     // eslint-disable-next-line no-await-in-loop
     await ctx.setFieldValue(key, clean);
   }
 
   savingClean = true;
   try {
+    console.log('[sanitize-richtext] calling saveCurrentItem...');
     await ctx.saveCurrentItem(true);
+    console.log('[sanitize-richtext] saveCurrentItem done ✓');
   } finally {
     savingClean = false;
   }
 
-  return false; // block the original dirty save (clean version was saved above)
+  return false;
 }
 
 /* ─── Plugin entry point ─────────────────────────────────────────────────── */
 
+console.log('[sanitize-richtext] loading plugin, calling connect()...');
+console.log('[sanitize-richtext] is in iframe:', window.self !== window.top);
+console.log('[sanitize-richtext] window.DatoCmsPlugin (old SDK):', typeof window.DatoCmsPlugin);
+
 connect({
   overrideFieldExtensions(field) {
+    console.log('[sanitize-richtext] overrideFieldExtensions called for field:', {
+      apiKey: field.attributes.api_key,
+      type: field.attributes.field_type,
+    });
     if (field.attributes.field_type === 'text') {
       return { addons: [{ id: 'sanitize-richtext' }] };
     }
@@ -153,4 +224,8 @@ connect({
   renderFieldExtension: renderExtension,
 
   onBeforeItemUpsert: beforeSave,
+}).then(() => {
+  console.log('[sanitize-richtext] connect() resolved');
+}).catch((err) => {
+  console.error('[sanitize-richtext] connect() rejected', err);
 });

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -38,7 +38,7 @@ module.exports = {
   },
   plugins: [
     new HtmlWebpackPlugin({
-      title: 'DatoCMS Plugin',
+      template: path.join(__dirname, 'src/index.html'),
       minify: isProduction,
     }),
   ],


### PR DESCRIPTION
React error #299 was thrown because HtmlWebpackPlugin generated HTML without a mount point. Added src/index.html template with <div id=root> and a JS fallback that creates the container dynamically if missing.

Added detailed console.log at every stage:
- connect() call and resolution
- overrideFieldExtensions per-field invocation
- renderFieldExtension mount and ctx details
- SanitizeAddon render cycle with value/status info
- onBeforeItemUpsert: payload keys, dirty field detection, ctx methods
- setFieldValue / saveCurrentItem calls and results